### PR TITLE
Upgrading dependencies and updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,19 @@ The s3 middleware provides a wrapper `wrap-aws-s3-auth`.
 When making requests to s3, instruct the clj-http client to use the wrapper like so:
 
 ```clojure
-(clj-http.client/with-middleware (conj clj-http.client/default-middleware #'s3/wrap-aws-s3-auth #'s3/wrap-request-date)
+(clj-http.client/with-middleware
+  (conj clj-http.client/default-middleware #'s3/wrap-aws-s3-auth #'s3/wrap-request-date)
   (clj-http.client/get "https://s3.amazonaws.com/sample-bucket/sample-resource"
                         :aws-credentials {:access-key "AWS_ACCESS_KEY"
                                           :secret-key "AWS_SECRET_KEY"}))
 ```
 
 AWS requires a date header to be sent.  The date header is used to sign the auth header as well.  You can either provide the date header yourself or use the wrap-request-date middleware (as shown in the above example).
+
+When the AWS Temporary Security Credentials is setup using IAM roles, use `wrap-aws-credentials` as the wrapper like:
+
+```clojure
+(clj-http.client/with-middleware
+  (conj clj-http.client/default-middleware #'s3/wrap-aws-credentials #'s3/wrap-request-date)
+  (clj-http.client/get "https://s3.amazonaws.com/sample-bucket/sample-resource"))
+```

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-http "3.0.1"]
-                 [clj-time "0.11.0"]
-                 [com.amazonaws/aws-java-sdk-core "1.10.75" :exclusions [joda-time commons-logging]]]
+                 [clj-http "3.9.1"]
+                 [clj-time "0.15.0"]
+                 [com.amazonaws/aws-java-sdk-core "1.11.480" :exclusions [joda-time commons-logging]]]
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/test/clj_http_s3/test/middleware.clj
+++ b/test/clj_http_s3/test/middleware.clj
@@ -23,6 +23,7 @@
                 {:query-string nil
                  :user-info nil
                  :uri "/an-s3-object"
+                 :url "http://http.example/an-s3-object"
                  :server-port nil
                  :server-name "http.example"
                  :scheme :http
@@ -40,6 +41,7 @@
                   {:query-string nil
                    :user-info nil
                    :uri "/an-s3-object"
+                   :url "http://http.example/an-s3-object"
                    :server-port nil
                    :server-name "http.example"
                    :scheme :http


### PR DESCRIPTION
clj-http's wrap-url function retains the given "url" in the key :url from the version 3.8.0. Changed the expected data in tests to accommodate this change.